### PR TITLE
[MAIN] fix: fix elements removal on update

### DIFF
--- a/easd/core.py
+++ b/easd/core.py
@@ -77,7 +77,8 @@ class EASD:
                 mask &= s.isin(interval)
             else:
                 mask &= (s >= interval[0]) & (s <= interval[1])
-        return mask
+
+        return list(mask)
 
     def _jaccard_test(self, mask1, mask2):
         intersection = np.logical_and(mask1, mask2).sum()

--- a/easd/dataset.py
+++ b/easd/dataset.py
@@ -85,7 +85,7 @@ class Dataset:
     def get_col_index(self, col_name):
         return self._col_index[col_name]
 
-    def get_col_name(self, col_index):
+    def get_col_name(self, col_index) -> str:
         return self._map_rules_columns[col_index]
 
     def get_data(self) -> pd.DataFrame:

--- a/main.py
+++ b/main.py
@@ -81,9 +81,16 @@ def run_main(args: Namespace):
         ).as_dict()
         metrics_list.append(run_metrics)
 
-        _save_results(detailed_rules, tmp, float(mean_rule_size), run, info, output_dir_dataset)
+        _save_results(detailed_rules, tmp, float(mean_rule_size), run, info, run_metrics, output_dir_dataset)
 
-    _save_stats_and_plots(output_dir_dataset, figures_list, metrics_list)
+    if num_executions > 1:
+        _save_stats(output_dir_dataset, metrics_list)
+
+    for i, figure in enumerate(figures_list):
+        if i == 0:
+            figure.savefig(f"{output_dir_dataset}/top-{args.plt_rank}_best_rules.png")
+        else:
+            figure.savefig(f"{output_dir_dataset}/top-{i}_rule.png")
 
 
 def _save_results(
@@ -92,6 +99,7 @@ def _save_results(
     p_mean_rule_size: float,
     p_run: int,
     p_info: pd.DataFrame,
+    p_metrics: dict,
     p_output_dir_dataset: str,
 ):
     scores_list.append(p_detailed_rules["Rule_Score"].values)
@@ -106,8 +114,13 @@ def _save_results(
     csv_path_info = os.path.join(p_output_dir_dataset, csv_filename_info)
     p_info.to_csv(csv_path_info, sep=",", index=False)
 
+    metrics_filename = f"{dataset_name}_{p_run}_RulesMetricsResult.csv"
+    metrics_filename = os.path.join(p_output_dir_dataset, metrics_filename)
+    metrics_df = pd.DataFrame([p_metrics]).round(2)
+    metrics_df.to_csv(metrics_filename, index=False, float_format="%.4f")
 
-def _save_stats_and_plots(p_output_dir_dataset: str, p_figures_list: list, p_metrics_list: list[dict]):
+
+def _save_stats(p_output_dir_dataset: str, p_metrics_list: list[dict]):
     stats_filename = f"{dataset_name}_RulesStatsResult.csv"
     metrics_filename = f"{dataset_name}_RulesMetricsResult.csv"
     stats_path = os.path.join(p_output_dir_dataset, stats_filename)
@@ -121,12 +134,6 @@ def _save_stats_and_plots(p_output_dir_dataset: str, p_figures_list: list, p_met
     stats_data.round(2).to_csv(stats_path)
 
     output_metrics(p_metrics_list, metrics_path)
-
-    for i, figure in enumerate(p_figures_list):
-        if i == 0:
-            figure.savefig(f"{p_output_dir_dataset}/top-{args.plt_rank}_best_rules.png")
-        else:
-            figure.savefig(f"{p_output_dir_dataset}/top-{i}_rule.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Olá Déborah, boa noite!
Eu estava revisando nosso código enquanto estava escrevendo a metodologia e notei uma pequena incongruência na parte que atualizamos o Top-K. Notei que eu tinha feito a função '_rebuild_heap_from_topk', porque algumas regras adicionais estavam sendo colocadas no self.top_k_heap, mas notei que acabei cometendo algum erro, ao invés de 'limpar' o Top-k ao adicionar as regras, eu estava limpando quando havia um excesso de regras.
Isso pode ser um pouco problemático, não só em memória, mas em lógica também, pois agora fazemos a seguinte verificação antes de adicionar uma regra nova no Top-K:

if len(self.best_by_key) < self.ksize or (self.top_k_heap and fitness > self.top_k_heap[0][0])

O problema é que o self.top_k_heap estava ficando com algumas regras antigas que já haviam sido removidas, no caso eram regras de constraints que haviam sido atualizados e a versão com score inferior permanecia lá. A parte que pode prejudicar nossa lógica é o self.top_k_heap and fitness > self.top_k_heap[0][0], pois tendo um self.top_k_heap and fitness maior que K, não estamos checando se a regras nova é melhor que K.
Concertei o problema na causa dele mesmo, e adicionei uma tolerância EPSILON na checagem nova que você fez:

if len(self.best_by_key) < self.ksize or (self.top_k_heap and fitness > self.top_k_heap[0][0] + **EPSILON**):

Acha que essa mudança está fazendo mais sentido.
Agradeço desde já!
Atenciosamente,
Bruno Leal Fonseca